### PR TITLE
bugfixing missing readme_pypi in PyPI distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE.md
 include README.md
+include readme_pypi

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ def read(fname):
 	return open(os.path.join(os.path.dirname(__file__),fname)).read()
 
 setup(name='aostools',
-      version='2.2',
+      version='2.3.1',
       description='Helper functions for scientific postprocessing and analysis of netCDF data',
       long_description=read('readme_pypi'),
       keywords='atmospheric oceanic science netcdf analysis tools',


### PR DESCRIPTION
Adding `readme_pypi` to distribution. This file was missing in the PyPI distribution causing an error when istalling.